### PR TITLE
feat(i18n): add Spanish translations and 2-column education layout

### DIFF
--- a/src/components/educations.astro
+++ b/src/components/educations.astro
@@ -21,7 +21,7 @@ import { Image } from "astro:assets";
 </div>
 
 <div class="w3-content w3-container w3-padding-64 fade-in">
-  <div class="projects-grid">
+  <div class="projects-grid education-grid">
     {
       MyEducations.map((education: Education) => (
         <div class="project-card">

--- a/src/components/libraries.tsx
+++ b/src/components/libraries.tsx
@@ -84,7 +84,7 @@ export default function Libraries({ libraries, background }) {
               </div>
               <div class="project-card-body">
                 <h5 class="project-card-name">{library.name}</h5>
-                <p class="project-card-desc">{library.description}</p>
+                <p class="project-card-desc">{library.description[lang]}</p>
                 <span class="library-type-badge">{library.type}</span>
               </div>
             </a>

--- a/src/components/projects.astro
+++ b/src/components/projects.astro
@@ -39,7 +39,7 @@ import Github from "../images/projects/github.png";
           </div>
           <div class="project-card-body">
             <h5 class="project-card-name">{project.name}</h5>
-            <p class="project-card-desc">{project.description}</p>
+            <p class="project-card-desc" data-desc-en={project.description.en} data-desc-es={project.description.es}>{project.description.en}</p>
             <div class="project-card-links">
               {project.playstore && (
                 <a

--- a/src/components/technologies.astro
+++ b/src/components/technologies.astro
@@ -6,6 +6,17 @@ import type { Technology } from "../libraries/me/knowledges/technologies";
 const categories = [
   ...new Set(MyTechnologies.map((e: Technology) => e.category)),
 ];
+
+const categoryEs: Record<string, string> = {
+  Mobile: "Móvil",
+  Web: "Web",
+  "CI/CD": "CI/CD",
+  Deployments: "Despliegues",
+  Monitoring: "Monitoreo",
+  Storage: "Almacenamiento",
+  BigData: "Big Data",
+  Microcontrollers: "Microcontroladores",
+};
 ---
 
 <div
@@ -33,7 +44,7 @@ const categories = [
         return (
           <div class="tech-category-card">
             <div class="tech-category-header">
-              <span class="tech-category-name">{category}</span>
+              <span class="tech-category-name" data-desc-en={category} data-desc-es={categoryEs[category] ?? category}>{category}</span>
             </div>
             <div class="tech-badges-area">
               {items.map((technology: Technology) => (

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -212,6 +212,10 @@ body {
   gap: 1.5rem;
 }
 
+.education-grid {
+  grid-template-columns: repeat(2, 1fr);
+}
+
 @media (max-width: 992px) {
   .projects-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/src/libraries/me/knowledges/libraries.ts
+++ b/src/libraries/me/knowledges/libraries.ts
@@ -18,7 +18,7 @@ export interface Library {
     | "Rust"
     | "Matlab";
   name: string;
-  description: string;
+  description: { en: string; es: string };
   link: string;
 }
 
@@ -27,110 +27,150 @@ const libraries: Library[] = [
     image: pubDev,
     type: "Flutter",
     name: "jmixclientv1",
-    description: "Library to connect with jmix v1.x rest api",
+    description: {
+      en: "Library to connect with jmix v1.x rest api",
+      es: "Librería para conectarse con la API REST de jmix v1.x",
+    },
     link: "https://pub.dev/packages/jmixclientv1",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/tsframework",
-    description: "REST Framework for education purposes",
+    description: {
+      en: "REST Framework for education purposes",
+      es: "Framework REST para propósitos educativos",
+    },
     link: "https://www.npmjs.com/package/@danny270793/tsframework",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/hotreloader",
-    description: "Re-executes a command when a file changes on specific folder",
+    description: {
+      en: "Re-executes a command when a file changes on specific folder",
+      es: "Vuelve a ejecutar un comando cuando un archivo cambia en una carpeta específica",
+    },
     link: "https://www.npmjs.com/package/@danny270793/hotreloader",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/levenshtein",
-    description: "Computes levenshtein distance to find matchs between strings",
+    description: {
+      en: "Computes levenshtein distance to find matches between strings",
+      es: "Calcula la distancia de Levenshtein para encontrar coincidencias entre cadenas",
+    },
     link: "https://www.npmjs.com/package/@danny270793/levenshtein",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/azureservicesclient",
-    description:
-      "Library to connect and get metadata from Azure resources like synapse, storage accounts, etc",
+    description: {
+      en: "Library to connect and get metadata from Azure resources like synapse, storage accounts, etc",
+      es: "Librería para conectarse y obtener metadatos de recursos de Azure como Synapse, cuentas de almacenamiento, etc.",
+    },
     link: "https://www.npmjs.com/package/@danny270793/azureservicesclient",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/jmixclientv1",
-    description: "Library to connect with jmix v1.x rest api",
+    description: {
+      en: "Library to connect with jmix v1.x rest api",
+      es: "Librería para conectarse con la API REST de jmix v1.x",
+    },
     link: "https://www.npmjs.com/package/@danny270793/jmixclientv1",
   },
   {
     image: Npm,
     type: "Node",
     name: "@danny270793/jmixclientv2",
-    description: "Library to connect with jmix v2.x rest api",
+    description: {
+      en: "Library to connect with jmix v2.x rest api",
+      es: "Librería para conectarse con la API REST de jmix v2.x",
+    },
     link: "https://www.npmjs.com/package/@danny270793/jmixclientv2",
   },
   {
     image: Pip,
     type: "Python",
     name: "arguments-parser",
-    description: "Library to parse cmd arguments",
+    description: {
+      en: "Library to parse cmd arguments",
+      es: "Librería para analizar argumentos de línea de comandos",
+    },
     link: "https://pypi.org/project/arguments-parser/",
   },
   {
     image: DokcerHub,
     type: "DockerHub",
     name: "fake-http-server",
-    description:
-      "Fake http server wich returns the hostname of the running machine and the node name shared via environment variables",
+    description: {
+      en: "Fake http server which returns the hostname of the running machine and the node name shared via environment variables",
+      es: "Servidor HTTP falso que retorna el nombre del host de la máquina en ejecución y el nombre del nodo compartido mediante variables de entorno",
+    },
     link: "https://hub.docker.com/r/danny27071993/fake-http-server",
   },
   {
     image: DokcerHub,
     type: "DockerHub",
     name: "sqlserver",
-    description:
-      "Create sqlserver container with a database just passing the database name as parameter without the need of any external script",
+    description: {
+      en: "Create sqlserver container with a database just passing the database name as parameter without the need of any external script",
+      es: "Crea un contenedor de SQL Server con una base de datos pasando solo el nombre de la base de datos como parámetro, sin necesidad de scripts externos",
+    },
     link: "https://hub.docker.com/r/danny27071993/sqlserver",
   },
   {
     image: DokcerHub,
     type: "DockerHub",
     name: "ansible",
-    description: "Docker image with ansible pre-installed for ci purposes",
+    description: {
+      en: "Docker image with ansible pre-installed for ci purposes",
+      es: "Imagen Docker con Ansible preinstalado para propósitos de CI",
+    },
     link: "https://hub.docker.com/r/danny27071993/ansible",
   },
   {
     image: DokcerHub,
     type: "DockerHub",
     name: "terraform-azure",
-    description: "Docker image with azure cli pre-installed for ci purposes",
+    description: {
+      en: "Docker image with azure cli pre-installed for ci purposes",
+      es: "Imagen Docker con Azure CLI preinstalado para propósitos de CI",
+    },
     link: "https://hub.docker.com/r/danny27071993/terraform-azure",
   },
   {
     image: Arduino,
     type: "Arduino",
     name: "ShiftRegister",
-    description:
-      "Library to convert decimal numbers to binary and write out over shift registers",
+    description: {
+      en: "Library to convert decimal numbers to binary and write out over shift registers",
+      es: "Librería para convertir números decimales a binario y escribirlos en registros de desplazamiento",
+    },
     link: "https://github.com/danny270793/ArduinoShiftRegister",
   },
   {
     image: CratesIO,
     type: "Rust",
     name: "code-metadata",
-    description:
-      "Computes the metada of the projects: files by extention, lines by extention, average lines per file",
+    description: {
+      en: "Computes the metadata of the projects: files by extension, lines by extension, average lines per file",
+      es: "Calcula los metadatos de los proyectos: archivos por extensión, líneas por extensión, promedio de líneas por archivo",
+    },
     link: "https://crates.io/crates/code-metadata",
   },
   {
     image: Matlab,
     type: "Matlab",
     name: "PortCom",
-    description: "Library to read and plot data from serial port using Matlab",
+    description: {
+      en: "Library to read and plot data from serial port using Matlab",
+      es: "Librería para leer y graficar datos desde el puerto serial usando Matlab",
+    },
     link: "https://github.com/danny270793/MatlabPortCom",
   },
 ];

--- a/src/libraries/me/knowledges/projects.ts
+++ b/src/libraries/me/knowledges/projects.ts
@@ -9,7 +9,7 @@ import type { ImageMetadata } from "astro";
 export interface Project {
   image: ImageMetadata;
   name: string;
-  description: string;
+  description: { en: string; es: string };
   playstore: string | undefined;
   appstore: string | undefined;
   github: string | undefined;
@@ -19,7 +19,10 @@ const projects: Project[] = [
   {
     image: MaintAzureMonitoring,
     name: "Maint Azure Monitoring",
-    description: "App get insights (prices, ussage) from azure accout",
+    description: {
+      en: "App to get insights (prices, usage) from azure account",
+      es: "Aplicación para obtener información (precios, uso) de una cuenta de Azure",
+    },
     playstore:
       "https://play.google.com/store/apps/details?id=com.maintlatam.azure.pipelinesmonitoring.pipelines_monitoring",
     appstore: undefined,
@@ -28,7 +31,10 @@ const projects: Project[] = [
   {
     image: Speedometer,
     name: "Speedometer",
-    description: "App to measure the speed which the device is moving on",
+    description: {
+      en: "App to measure the speed which the device is moving on",
+      es: "Aplicación para medir la velocidad a la que se mueve el dispositivo",
+    },
     playstore:
       "https://play.google.com/store/apps/details?id=io.github.danny270793.sppedometer",
     appstore: undefined,
@@ -37,8 +43,10 @@ const projects: Project[] = [
   {
     image: Soundmeter,
     name: "Soundmeter",
-    description:
-      "App to measure the strengh of the noise which is reaching your phone microphone",
+    description: {
+      en: "App to measure the strength of the noise which is reaching your phone microphone",
+      es: "Aplicación para medir la intensidad del ruido que llega al micrófono de tu teléfono",
+    },
     playstore:
       "https://play.google.com/store/apps/details?id=io.github.danny270793.soundmeter.soundmeter",
     appstore: undefined,
@@ -47,7 +55,10 @@ const projects: Project[] = [
   {
     image: Mycompass,
     name: "Mycompass",
-    description: "App to measure the orientation of the device",
+    description: {
+      en: "App to measure the orientation of the device",
+      es: "Aplicación para medir la orientación del dispositivo",
+    },
     playstore:
       "https://play.google.com/store/apps/details?id=io.github.danny270793.mycompass",
     appstore: undefined,
@@ -56,8 +67,10 @@ const projects: Project[] = [
   {
     image: BoxingTimer,
     name: "Boxing Timer",
-    description:
-      "A app that shows a timer for each round of your boxing training",
+    description: {
+      en: "App that shows a timer for each round of your boxing training",
+      es: "Aplicación que muestra un temporizador para cada round de tu entrenamiento de boxeo",
+    },
     playstore:
       "https://play.google.com/store/apps/details?id=io.github.danny270793.boxingtimer",
     appstore: undefined,
@@ -66,7 +79,10 @@ const projects: Project[] = [
   {
     image: MMAScoreCard,
     name: "MMA ScoreCard",
-    description: "An independent app to see MMA events and results",
+    description: {
+      en: "An independent app to see MMA events and results",
+      es: "Aplicación independiente para ver eventos y resultados de MMA",
+    },
     playstore: undefined,
     appstore: undefined,
     github: "https://github.com/danny270793/MMAScoreCard",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -146,6 +146,13 @@ import OpenSourceLibrariesBackground from "../images/parallax/open source librar
                 .map((p) => `<p style="margin: 0 0 1rem;">${p}</p>`)
                 .join("");
             });
+          document
+            .querySelectorAll<HTMLElement>("[data-desc-en]")
+            .forEach((el) => {
+              el.textContent =
+                (lang === "es" ? el.dataset.descEs : el.dataset.descEn) ??
+                el.textContent;
+            });
           document.documentElement.lang = lang;
           window.dispatchEvent(
             new CustomEvent<Language>("i18n:change", { detail: lang }),


### PR DESCRIPTION
## Summary

- Added Spanish (`es`) translations for all project and library descriptions alongside the existing English (`en`) versions — descriptions are now `{ en, es }` objects
- Fixed typos in existing English descriptions (`ussage`, `strengh`, `metada`, `extention`, `matchs`, `wich`)
- Technology category names (Deployments, Monitoring, Storage, Microcontrollers, etc.) are now translated to Spanish on language switch
- `applyLang` in `index.astro` updated to swap `[data-desc-en/es]` elements on language change
- Education section now renders in a 2-column grid instead of 3 via a new `education-grid` CSS class

## Test plan

- [ ] Switch language to ES and verify project descriptions update in Spanish
- [ ] Switch language to ES and verify library descriptions update in Spanish
- [ ] Switch language to ES and verify technology category names update in Spanish
- [ ] Verify education section shows 2 cards per row on desktop
- [ ] Verify education section collapses correctly on tablet (≤992px) and mobile (≤600px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)