### PR TITLE
style: format astro components and fix trailing whitespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ A noun in parentheses after the type, e.g. `fix(postgres): handle null connectio
 
 Either:
 
-- append **`!`** after the type/scope: `feat(api)!: remove legacy endpoint`, or  
+- append **`!`** after the type/scope: `feat(api)!: remove legacy endpoint`, or
 - add a footer: `BREAKING CHANGE: <what changed and what to do>`.
 
 ### Examples (valid)

--- a/src/components/projects.astro
+++ b/src/components/projects.astro
@@ -39,7 +39,13 @@ import Github from "../images/projects/github.png";
           </div>
           <div class="project-card-body">
             <h5 class="project-card-name">{project.name}</h5>
-            <p class="project-card-desc" data-desc-en={project.description.en} data-desc-es={project.description.es}>{project.description.en}</p>
+            <p
+              class="project-card-desc"
+              data-desc-en={project.description.en}
+              data-desc-es={project.description.es}
+            >
+              {project.description.en}
+            </p>
             <div class="project-card-links">
               {project.playstore && (
                 <a

--- a/src/components/technologies.astro
+++ b/src/components/technologies.astro
@@ -44,7 +44,13 @@ const categoryEs: Record<string, string> = {
         return (
           <div class="tech-category-card">
             <div class="tech-category-header">
-              <span class="tech-category-name" data-desc-en={category} data-desc-es={categoryEs[category] ?? category}>{category}</span>
+              <span
+                class="tech-category-name"
+                data-desc-en={category}
+                data-desc-es={categoryEs[category] ?? category}
+              >
+                {category}
+              </span>
             </div>
             <div class="tech-badges-area">
               {items.map((technology: Technology) => (


### PR DESCRIPTION
## Summary

- Removed trailing whitespace in `AGENTS.md`
- Reformatted multi-attribute `<p>` in `projects.astro` to multi-line style
- Reformatted multi-attribute `<span>` in `technologies.astro` to multi-line style

All changes are formatter/linter output only — no logic changes.

## Test plan

- [ ] Verify the site builds without errors
- [ ] Confirm no visual or behavioural regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)